### PR TITLE
Expand imported but unused namespaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -74,3 +74,6 @@ dotnet_style_qualification_for_property = false:none
 
 
 dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0057
+csharp_style_prefer_range_operator = false:silent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Embed defined namespace
+- Expand imported but unused namespaces
 
 ## [4.0.2] - 2022-01-23
 - Downgrade libraries SourceExpander.Embedder.Testing

--- a/Source/SourceExpander.Console/SourceExpander.Console.csproj
+++ b/Source/SourceExpander.Console/SourceExpander.Console.csproj
@@ -32,7 +32,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Base32768" Version="2.0.2" />
-		<PackageReference Include="ConsoleAppFramework" Version="4.0.5" />
+		<PackageReference Include="ConsoleAppFramework" Version="4.0.6" />
 		<PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
 		<PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />

--- a/Source/SourceExpander.Share/Core/SourceFileContainer.cs
+++ b/Source/SourceExpander.Share/Core/SourceFileContainer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading;
@@ -17,7 +18,9 @@ namespace SourceExpander
         {
             _sourceFiles = new();
             _sourceFilesByTypeName = new();
+            var definedNamespacesBuilder = ImmutableHashSet.CreateBuilder<string>();
             foreach (var embedded in embeddedDatas)
+            {
                 foreach (var sf in embedded.Sources)
                 {
                     if (sf.FileName == null) throw new ArgumentException($"({nameof(sf.FileName)} is null");
@@ -32,7 +35,13 @@ namespace SourceExpander
                         list.Add(sf);
                     }
                 }
+                definedNamespacesBuilder.UnionWith(embedded.EmbeddedNamespaces);
+            }
+
+            DefinedNamespaces = definedNamespacesBuilder.ToImmutable();
         }
+
+        public ImmutableHashSet<string> DefinedNamespaces { get; }
 
         public int Count => _sourceFiles.Count;
         public SourceFileInfo this[string filename]

--- a/Test/SourceExpander.Generator.Test/Generate/AllowUnsafe.Test.cs
+++ b/Test/SourceExpander.Generator.Test/Generate/AllowUnsafe.Test.cs
@@ -16,9 +16,11 @@ namespace SourceExpander.Generate
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedAllowUnsafe"",""true"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedAllowUnsafe"",""true"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
 
@@ -95,9 +97,11 @@ class Program
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedAllowUnsafe"",""false"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedAllowUnsafe"",""false"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
 

--- a/Test/SourceExpander.Generator.Test/Generate/ConfigTest.cs
+++ b/Test/SourceExpander.Generator.Test/Generate/ConfigTest.cs
@@ -62,9 +62,11 @@ namespace SourceExpander.Generate
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
 
@@ -168,9 +170,11 @@ namespace Other { public static class C { public static void P() => System.Conso
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
             var additionalText = new InMemorySourceText(
@@ -239,9 +243,11 @@ class Program2
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
 
@@ -383,9 +389,11 @@ namespace Other { public static class C { public static void P() => System.Conso
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
             var pattern = @"mine/Program.cs";
@@ -482,9 +490,11 @@ namespace Other { public static class C { public static void P() => System.Conso
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
 
@@ -594,9 +604,11 @@ namespace Other { public static class C { public static void P() => System.Conso
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
 
@@ -708,9 +720,11 @@ namespace Other { public static class C { public static void P() => System.Conso
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
 

--- a/Test/SourceExpander.Generator.Test/Generate/Default.NoCoreReference.Test.cs
+++ b/Test/SourceExpander.Generator.Test/Generate/Default.NoCoreReference.Test.cs
@@ -18,9 +18,11 @@ namespace SourceExpander.Generate
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
 

--- a/Test/SourceExpander.Generator.Test/Generate/Default.WithCoreReference.Test.cs
+++ b/Test/SourceExpander.Generator.Test/Generate/Default.WithCoreReference.Test.cs
@@ -16,9 +16,11 @@ namespace SourceExpander.Generate
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
 

--- a/Test/SourceExpander.Generator.Test/Generate/ExtensionMethod.Test.cs
+++ b/Test/SourceExpander.Generator.Test/Generate/ExtensionMethod.Test.cs
@@ -20,8 +20,10 @@ namespace SourceExpander.Generate
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]},{\""CodeBody\"":\""namespace Other.Linq{public static class L{public static int Max(this int v)=>v;}}\"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>L.cs\"",\""TypeNames\"":[\""Other.Linq.L\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""2147483647.2147483647.2147483647.2147483647"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]},{\""CodeBody\"":\""namespace Other.Linq{public static class L{public static int Max(this int v)=>v;}}\"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>L.cs\"",\""TypeNames\"":[\""Other.Linq.L\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other,Other.Linq"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""2147483647.2147483647.2147483647.2147483647"")]")
                 ),
             };
 
@@ -86,6 +88,100 @@ namespace Name
 #region Expanded by https://github.com/kzrnm/SourceExpander
 namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } 
 namespace Other.Linq{public static class L{public static int Max(this int v)=>v;}}
+#endregion Expanded by https://github.com/kzrnm/SourceExpander".ReplaceEOL().ToLiteral()
++ @"},})},
+};
+}}").ReplaceEOL())
+                    }
+                }
+            };
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task UnusedExtensionMethod()
+        {
+            var others = new SourceFileCollection{
+                (
+                @"/home/other/C.cs",
+                "namespace Other{public static class C{public static void P()=>System.Console.WriteLine();}}"
+                ),
+                (
+                @"/home/other/L.cs",
+                "namespace Other.Linq{public static class L{public static int Max(this int v)=>v;}}"
+                ),
+                (
+                @"/home/other/AssemblyInfo.cs",
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]},{\""CodeBody\"":\""namespace Other.Linq{public static class L{public static int Max(this int v)=>v;}}\"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>L.cs\"",\""TypeNames\"":[\""Other.Linq.L\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other,Other.Linq"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""2147483647.2147483647.2147483647.2147483647"")]")
+                ),
+            };
+
+            var test = new Test
+            {
+                SolutionTransforms =
+                {
+                    (solution, projectId)
+                    => CreateOtherReference(solution, projectId, others),
+                },
+                TestState =
+                {
+                    Sources = {
+                        (
+                            @"/home/mine/Program.cs",
+                            @"using System;
+using Other;
+using Other.Linq;
+using System.Linq;
+
+namespace Name 
+{
+    class Program
+    {
+        static void Main()
+        {
+            Console.WriteLine(42);
+            C.P();
+            new int[1].Max();
+        }
+    }
+}
+"
+                        ),
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        DiagnosticResult.CompilerWarning("EXPAND0002").WithArguments(ExpanderVersion, "Other", "2147483647.2147483647.2147483647.2147483647"),
+                    },
+                    GeneratedSources =
+                    {
+                        (typeof(ExpandGenerator), "SourceExpander.Expanded.cs", (@"using System.Collections.Generic;
+namespace SourceExpander.Expanded{
+public static class ExpandedContainer{
+public static IReadOnlyDictionary<string, SourceCode> Files {get{ return _Files; }}
+private static Dictionary<string, SourceCode> _Files = new Dictionary<string, SourceCode>{
+{""/home/mine/Program.cs"",SourceCode.FromDictionary(new Dictionary<string,object>{{""path"",""/home/mine/Program.cs""},{""code"","
++ @"using Other;
+using Other.Linq;
+using System;
+using System.Linq;
+namespace Name 
+{
+    class Program
+    {
+        static void Main()
+        {
+            Console.WriteLine(42);
+            C.P();
+            new int[1].Max();
+        }
+    }
+}
+#region Expanded by https://github.com/kzrnm/SourceExpander
+namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } 
+namespace Other.Linq{}
 #endregion Expanded by https://github.com/kzrnm/SourceExpander".ReplaceEOL().ToLiteral()
 + @"},})},
 };

--- a/Test/SourceExpander.Generator.Test/Generate/InvalidEmbeddedData.cs
+++ b/Test/SourceExpander.Generator.Test/Generate/InvalidEmbeddedData.cs
@@ -17,9 +17,10 @@ namespace SourceExpander.Generate
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[-]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[-]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
             };
 

--- a/Test/SourceExpander.Generator.Test/Generate/LangVersion.Test.cs
+++ b/Test/SourceExpander.Generator.Test/Generate/LangVersion.Test.cs
@@ -16,9 +16,11 @@ namespace SourceExpander.Generate
                 ),
             (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""1.1.1.1"")]")
                 ),
         };
 

--- a/Test/SourceExpander.Generator.Test/Generate/OlderVersion.Test.cs
+++ b/Test/SourceExpander.Generator.Test/Generate/OlderVersion.Test.cs
@@ -16,8 +16,11 @@ namespace SourceExpander.Generate
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""2147483647.2147483647.2147483647.2147483647"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedLanguageVersion"",""7.2"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""2147483647.2147483647.2147483647.2147483647"")]")
                 ),
             };
 

--- a/Test/SourceExpander.Generator.Test/Generate/UsingRemover.Test.cs
+++ b/Test/SourceExpander.Generator.Test/Generate/UsingRemover.Test.cs
@@ -16,8 +16,10 @@ namespace SourceExpander.Generate
                 ),
                 (
                 @"/home/other/AssemblyInfo.cs",
-                @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]"
-                + @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""2147483647.2147483647.2147483647.2147483647"")]"
+                EnvironmentUtil.JoinByStringBuilder(
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedSourceCode"", ""[{\""CodeBody\"":\""namespace Other { public static class C { public static void P() => System.Console.WriteLine(); } } \"",\""Dependencies\"":[],\""FileName\"":\""OtherDependency>C.cs\"",\""TypeNames\"":[\""Other.C\""],\""Usings\"":[]}]"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbeddedNamespaces"", ""Other"")]",
+                    @"[assembly: System.Reflection.AssemblyMetadata(""SourceExpander.EmbedderVersion"",""2147483647.2147483647.2147483647.2147483647"")]")
                 ),
             };
 

--- a/Test/SourceExpander.Share.Test/EmbeddedDataTest.cs
+++ b/Test/SourceExpander.Share.Test/EmbeddedDataTest.cs
@@ -17,8 +17,9 @@ namespace SourceExpander.Share
                     "Empty",
                     ImmutableArray.Create<SourceFileInfo>(),
                     new Version(1, 0, 0),
-                    LanguageVersion.CSharp1
-                    , false
+                    LanguageVersion.CSharp1,
+                    false,
+                    ImmutableArray<string>.Empty
                     ), ImmutableArray<(string Key, string Message)>.Empty));
         }
 
@@ -33,7 +34,8 @@ namespace SourceExpander.Share
                     ImmutableArray.Create<SourceFileInfo>(),
                     new Version(3, 4, 0, 0),
                     LanguageVersion.CSharp1,
-                    false
+                    false,
+                    ImmutableArray<string>.Empty
                     ), ImmutableArray<(string Key, string Message)>.Empty));
         }
 
@@ -53,7 +55,8 @@ namespace SourceExpander.Share
                     ImmutableArray.Create<SourceFileInfo>(),
                     new Version(1, 0, 0),
                     expectedVersion,
-                    false
+                    false,
+                    ImmutableArray<string>.Empty
                     ), ImmutableArray<(string Key, string Message)>.Empty));
         }
 
@@ -89,11 +92,13 @@ namespace SourceExpander.Share
                 ),
                 new Version(3, 4, 0, 0),
                 LanguageVersion.CSharp7_3,
-                false
+                    false,
+                    ImmutableArray.Create("SampleLibrary")
                 );
             EmbeddedData.Create("RawJson",
                 ImmutableDictionary.Create<string, string>()
                 .Add("SourceExpander.EmbeddedSourceCode", json)
+                .Add("SourceExpander.EmbeddedNamespaces", "SampleLibrary")
                 .Add("SourceExpander.EmbedderVersion", "3.4.0.0")
                 .Add("SourceExpander.EmbeddedLanguageVersion", "7.3"))
                 .Should()
@@ -102,6 +107,7 @@ namespace SourceExpander.Share
             EmbeddedData.Create("RawJson",
                 ImmutableDictionary.Create<string, string>()
                .Add("SourceExpander.EmbeddedLanguageVersion", "7.3")
+                .Add("SourceExpander.EmbeddedNamespaces", "SampleLibrary")
                .Add("SourceExpander.EmbedderVersion", "3.4.0.0")
                .Add("SourceExpander.EmbeddedSourceCode", json))
                 .Should()
@@ -116,19 +122,23 @@ namespace SourceExpander.Share
                 ImmutableDictionary.Create<string, string>()
                 .Add("SourceExpander.EmbeddedSourceCode", json)
                 .Add("SourceExpander.EmbedderVersion", "3.4.0.0")
+                .Add("SourceExpander.EmbeddedNamespaces", "SampleLibrary")
                 .Add("SourceExpander.EmbeddedLanguageVersion", "7.3"))
                 .Should()
                 .BeEquivalentTo((
                 new EmbeddedData("RawJson",
                 ImmutableArray<SourceFileInfo>.Empty,
                 new(3, 4, 0, 0),
-                LanguageVersion.CSharp7_3, false),
+                LanguageVersion.CSharp7_3,
+                false,
+                ImmutableArray.Create("SampleLibrary")),
                 ImmutableArray.Create<(string Key, string Message)>(("SourceExpander.EmbeddedSourceCode",
                 "Invalid property identifier character: ]. Path '[0]', line 1, position 2."))));
 
             EmbeddedData.Create("RawJson",
                 ImmutableDictionary.Create<string, string>()
                .Add("SourceExpander.EmbeddedLanguageVersion", "7.3")
+               .Add("SourceExpander.EmbeddedNamespaces", "SampleLibrary")
                .Add("SourceExpander.EmbedderVersion", "3.4.0.0")
                .Add("SourceExpander.EmbeddedSourceCode", json))
                 .Should()
@@ -136,7 +146,9 @@ namespace SourceExpander.Share
                 new EmbeddedData("RawJson",
                 ImmutableArray<SourceFileInfo>.Empty,
                 new(3, 4, 0, 0),
-                LanguageVersion.CSharp7_3, false),
+                LanguageVersion.CSharp7_3,
+                false,
+                ImmutableArray.Create("SampleLibrary")),
                 ImmutableArray.Create<(string Key, string Message)>(("SourceExpander.EmbeddedSourceCode",
                 "Invalid property identifier character: ]. Path '[0]', line 1, position 2."))));
         }
@@ -157,11 +169,13 @@ namespace SourceExpander.Share
                 ),
                 new Version(3, 4, 0, 0),
                 LanguageVersion.CSharp1,
-                false
+                false,
+                ImmutableArray.Create("SampleLibrary")
                 );
 
             EmbeddedData.Create("GZipBase32768", ImmutableDictionary.Create<string, string>()
                 .Add("SourceExpander.EmbeddedSourceCode.GZipBase32768", gzipBase32768)
+                .Add("SourceExpander.EmbeddedNamespaces", "SampleLibrary")
                 .Add("SourceExpander.EmbedderVersion", "3.4.0.0")
             )
                 .Should()
@@ -169,6 +183,7 @@ namespace SourceExpander.Share
             EmbeddedData.Create("GZipBase32768", ImmutableDictionary.Create<string, string>()
                 .Add("SourceExpander.EmbedderVersion", "3.4.0.0")
                 .Add("SourceExpander.EmbeddedLanguageVersion", "1")
+                .Add("SourceExpander.EmbeddedNamespaces", "SampleLibrary")
                 .Add("SourceExpander.EmbeddedSourceCode.GZipBase32768", gzipBase32768)
             )
                 .Should()


### PR DESCRIPTION
Fix #69

## Current behavior

When a extension method is used, all extension methods that have same name as the method are regarded as `used`.

https://github.com/dotnet/roslyn/issues/54283

**library**
```csharp:Library.cs
namespace Other.Linq
{
    public static class L
    {
        public int Max(this int v) => v;
    }
}
```

**caller**

```csharp:Program.cs
using Other.Linq;
using System.Linq;

namespace Name 
{
    class Program
    {
        static void Main()
        {
            new int[1].Max();
        }
    }
}
```

**expanded**

```csharp
using Other.Linq;
using System.Linq;
namespace Name 
{
    class Program
    {
        static void Main()
        {
            new int[1].Max();
        }
    }
}
#region Expanded by https://github.com/kzrnm/SourceExpander
#endregion Expanded by https://github.com/kzrnm/SourceExpander
```

## New behavior
Expand imported but unused namespaces 

**expanded**

```csharp
using Other.Linq;
using System.Linq;
namespace Name 
{
    class Program
    {
        static void Main()
        {
            new int[1].Max();
        }
    }
}
#region Expanded by https://github.com/kzrnm/SourceExpander
namespace Other.Linq{}
#endregion Expanded by https://github.com/kzrnm/SourceExpander
```